### PR TITLE
CORE-973 CORE-974 Component Categories and Localized Component Titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 3.3.0 ##
 * Core dependency updated **>=8.6**
+### Improvements
+* !37 CORE-973 Added Component `Thank You` to Category `People, Communication & Social`.
+* !37 CORE-974 Added Localized Titles to the `Thank You` Component.
 
 ## 3.2.4
 * Added Russian translations and twig template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log #
 
+## Version 3.3.0 ##
+* Core dependency updated **>=8.6**
+
 ## 3.2.4
 * Added Russian translations and twig template
 

--- a/classes/UI/PagesComponent.php
+++ b/classes/UI/PagesComponent.php
@@ -8,6 +8,7 @@ use Claromentis\Core\Component\OptionsInterface;
 use Claromentis\Core\Component\TemplaterTrait;
 use Claromentis\ThankYou\ThanksRepository;
 use Claromentis\ThankYou\View\ThanksListView;
+use ClaText;
 
 /**
  * 'Thank you' component for Pages application. Shows list of latest "thanks" and optionally
@@ -101,9 +102,9 @@ class PagesComponent implements ComponentInterface, MutatableOptionsInterface
 	 * Render component header with the specified options.
 	 * If null or empty string is returned, header is not displayed.
 	 *
-	 * @param string $id_string
+	 * @param string           $id_string
 	 * @param OptionsInterface $options
-	 * @param Application $app
+	 * @param Application      $app
 	 *
 	 * @return string
 	 */
@@ -128,12 +129,13 @@ class PagesComponent implements ComponentInterface, MutatableOptionsInterface
 
 		if ($options->Get('title') !== '')
 		{
-			$args['custom_title.body'] = $options->Get('title');
-			$args['custom_title.visible'] = 1;
+			$args['custom_title.body']     = cla_htmlsafe(ClaText::ProcessAvailableLocalisation((string) $options->Get('title')));
+			$args['custom_title.visible']  = 1;
 			$args['default_title.visible'] = 0;
 		}
 
 		$template = 'thankyou/pages_component_header.html';
+
 		return $this->CallTemplater($template, $args);
 	}
 
@@ -184,10 +186,11 @@ class PagesComponent implements ComponentInterface, MutatableOptionsInterface
 	public function GetCoverInfo()
 	{
 		return [
-			'title' => lmsg('thankyou.component.cover_info.title'),
+			'title'       => lmsg('thankyou.component.cover_info.title'),
 			'description' => lmsg('thankyou.component.cover_info.desc'),
 			'application' => 'thankyou',
-			'icon_class' => 'glyphicons glyphicons-donate'
+			'icon_class'  => 'glyphicons glyphicons-donate',
+			'categories'  => ['people']
 		];
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "require": {
         "php": ">=5.6.0",
         "claromentis/installer-composer-plugin": "^1.2.3",
-        "claromentis/framework": ">=8.2"
+        "claromentis/framework": ">=8.6"
     }
 }


### PR DESCRIPTION
Note: This MR should not be reviewed until the following MRs have been completed:
* https://gitlab.com/claromentis/product/pages/merge_requests/26
* https://gitlab.com/claromentis/product/core/merge_requests/520

The following Components have been categorised:
* Thank You: `People, Communication & Social`

The following Components will now support user defined Localizations in their Titles:
* Thank You

<!-- Describe the change. -->

### Related issues
* CORE-951: https://claromentis.atlassian.net/browse/CORE-951
* CORE-973: https://claromentis.atlassian.net/browse/CORE-973
* CORE-974: https://claromentis.atlassian.net/browse/CORE-974
<!-- List links to related issues in Jira/Disco/Prototypes. -->

### Test criteria
- [x] The Component `Thank You` displays under `All Categories` and `People, Communication & Social`.
- [x] The Component `Thank You` supports User defined Localizations in its Title.
<!-- List the criteria that should be met when QA testing. -->

### Breaking changes
* Core dependency updated to >=8.6
<!-- List any backwards-compatibility breaking changes. -->

### Review criteria

Criteria that must be met before review and testing. Check these as they are completed.

- [x] Change log updated
- [x] Title and description are clear and accurate
- [x] Related issues listed (Jira issues, Disco tickets, prototypes)
- [x] Test criteria listed clearly
- [x] Breaking changes listed