### PR TITLE
BT-680 Fixed missing User Picker Localizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log #
 
+## 3.2.5 Unreleased
+* !38 BT-680 Fixed missing Localizations in User Picker.
+
 ## 3.2.4
 * Added Russian translations and twig template
 

--- a/html/includes/modal.html
+++ b/html/includes/modal.html
@@ -13,6 +13,7 @@
 
 						<div class="form-control-static col-sm-10">
 							<txt name="select_user" visible="1">
+								<include file="../../common/select2_inc.html">
 								<component class_key="user_picker" name="thank_you_user" multiple="1" id="thank_you_user" />
 							</txt>
 							<txt name="preselected_user" visible="0">


### PR DESCRIPTION
Fixed either missing or unlocalized phrases on the User Picker.

### Related issues
BT-673: https://claromentis.atlassian.net/browse/BT-673
BT-680: https://claromentis.atlassian.net/browse/BT-680
<!-- List links to related issues in Jira/Disco/Prototypes. -->

### Test criteria
- [x] The User Picker should display Localised messages for all of its warnings.
<!-- List the criteria that should be met when QA testing. -->

### Review criteria

Criteria that must be met before review and testing. Check these as they are completed.

- [x] Change log updated
- [x] Title and description are clear and accurate
- [x] Related issues listed (Jira issues, Disco tickets, prototypes)
- [x] Test criteria listed clearly

/label ~bug
